### PR TITLE
Add Admin Mode Authentication (Fix #5)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,14 +5,63 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends, Header
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
 import os
+import json
 from pathlib import Path
+from typing import Optional
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Pydantic models
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+class LoginResponse(BaseModel):
+    success: bool
+    message: str
+    username: Optional[str] = None
+
+# Load teachers from JSON file
+def load_teachers():
+    teachers_file = Path(__file__).parent.parent / "teachers.json"
+    try:
+        with open(teachers_file, 'r') as f:
+            data = json.load(f)
+            return data.get("teachers", [])
+    except FileNotFoundError:
+        return []
+
+# Verify teacher authentication
+def verify_teacher(authorization: Optional[str] = Header(None)):
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    
+    # Simple token validation (username:password)
+    try:
+        username, password = authorization.split(":")
+        teachers = load_teachers()
+        for teacher in teachers:
+            if teacher["username"] == username and teacher["password"] == password:
+                return username
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    except ValueError:
+        raise HTTPException(status_code=401, detail="Invalid authorization format")
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
@@ -83,14 +132,31 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.post("/auth/login")
+def login(request: LoginRequest):
+    """Authenticate a teacher"""
+    teachers = load_teachers()
+    for teacher in teachers:
+        if teacher["username"] == request.username and teacher["password"] == request.password:
+            return LoginResponse(
+                success=True,
+                message="Login successful",
+                username=request.username
+            )
+    return LoginResponse(
+        success=False,
+        message="Invalid username or password"
+    )
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, teacher: str = Depends(verify_teacher)):
+    """Sign up a student for an activity (teachers only)"""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -111,8 +177,8 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, teacher: str = Depends(verify_teacher)):
+    """Unregister a student from an activity (teachers only)"""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,118 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const loginBtn = document.getElementById("login-btn");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+  const userInfo = document.getElementById("user-info");
+  const usernameDisplay = document.getElementById("username-display");
+  const logoutBtn = document.getElementById("logout-btn");
+  const closeModal = document.querySelector(".close");
+  const signupContainer = document.getElementById("signup-container");
+
+  // Authentication state
+  let authToken = localStorage.getItem("authToken");
+  let currentUser = localStorage.getItem("currentUser");
+
+  // Update UI based on authentication
+  function updateAuthUI() {
+    if (authToken && currentUser) {
+      loginBtn.classList.add("hidden");
+      userInfo.classList.remove("hidden");
+      usernameDisplay.textContent = `👤 ${currentUser}`;
+      signupContainer.classList.remove("hidden");
+      
+      // Show delete buttons
+      document.querySelectorAll(".delete-btn").forEach(btn => {
+        btn.style.display = "inline-block";
+      });
+    } else {
+      loginBtn.classList.remove("hidden");
+      userInfo.classList.add("hidden");
+      signupContainer.classList.add("hidden");
+      
+      // Hide delete buttons
+      document.querySelectorAll(".delete-btn").forEach(btn => {
+        btn.style.display = "none";
+      });
+    }
+  }
+
+  // Show login modal
+  loginBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+  });
+
+  // Close modal
+  closeModal.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  // Close modal when clicking outside
+  window.addEventListener("click", (event) => {
+    if (event.target === loginModal) {
+      loginModal.classList.add("hidden");
+    }
+  });
+
+  // Handle login
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+
+      const result = await response.json();
+
+      if (result.success) {
+        authToken = `${username}:${password}`;
+        currentUser = username;
+        localStorage.setItem("authToken", authToken);
+        localStorage.setItem("currentUser", currentUser);
+        
+        loginMessage.textContent = "Login successful!";
+        loginMessage.className = "success";
+        loginMessage.classList.remove("hidden");
+        
+        setTimeout(() => {
+          loginModal.classList.add("hidden");
+          loginForm.reset();
+          loginMessage.classList.add("hidden");
+          updateAuthUI();
+          fetchActivities(); // Refresh to show delete buttons
+        }, 1000);
+      } else {
+        loginMessage.textContent = result.message;
+        loginMessage.className = "error";
+        loginMessage.classList.remove("hidden");
+      }
+    } catch (error) {
+      loginMessage.textContent = "Login failed. Please try again.";
+      loginMessage.className = "error";
+      loginMessage.classList.remove("hidden");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  // Handle logout
+  logoutBtn.addEventListener("click", () => {
+    authToken = null;
+    currentUser = null;
+    localStorage.removeItem("authToken");
+    localStorage.removeItem("currentUser");
+    updateAuthUI();
+    fetchActivities(); // Refresh to hide delete buttons
+  });
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -30,7 +142,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}" style="display: ${authToken ? 'inline-block' : 'none'}">❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -73,6 +185,16 @@ document.addEventListener("DOMContentLoaded", () => {
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
 
+    if (!authToken) {
+      messageDiv.textContent = "Please login as a teacher to unregister students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 3000);
+      return;
+    }
+
     try {
       const response = await fetch(
         `/activities/${encodeURIComponent(
@@ -80,6 +202,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: {
+            "Authorization": authToken,
+          },
         }
       );
 
@@ -114,6 +239,16 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!authToken) {
+      messageDiv.textContent = "Please login as a teacher to sign up students.";
+      messageDiv.className = "error";
+      messageDiv.classList.remove("hidden");
+      setTimeout(() => {
+        messageDiv.classList.add("hidden");
+      }, 3000);
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +259,9 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: {
+            "Authorization": authToken,
+          },
         }
       );
 
@@ -156,5 +294,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
+  updateAuthUI();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,34 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="user-menu">
+        <button id="login-btn" class="user-icon">👤 Login</button>
+        <div id="user-info" class="hidden">
+          <span id="username-display"></span>
+          <button id="logout-btn">Logout</button>
+        </div>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close">&times;</span>
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required />
+          </div>
+          <button type="submit">Login</button>
+        </form>
+        <div id="login-message" class="hidden"></div>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">
@@ -21,8 +48,8 @@
         </div>
       </section>
 
-      <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+      <section id="signup-container" class="teacher-only hidden">
+        <h3>Sign Up for an Activity (Teachers Only)</h3>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,10 +22,103 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
 }
 
 header h1 {
   margin-bottom: 10px;
+}
+
+#user-menu {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.user-icon {
+  background-color: #fff;
+  color: #1a237e;
+  border: none;
+  padding: 8px 15px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.user-icon:hover {
+  background-color: #e0e0e0;
+}
+
+#user-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+#username-display {
+  color: white;
+  font-weight: bold;
+}
+
+#logout-btn {
+  background-color: #ff5252;
+  color: white;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+#logout-btn:hover {
+  background-color: #ff1744;
+}
+
+/* Modal Styles */
+.modal {
+  display: block;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+
+.modal-content {
+  background-color: white;
+  margin: 10% auto;
+  padding: 30px;
+  border-radius: 10px;
+  width: 90%;
+  max-width: 400px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+  cursor: pointer;
+  line-height: 20px;
+}
+
+.close:hover,
+.close:focus {
+  color: #000;
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+  text-align: center;
 }
 
 main {

--- a/teachers.json
+++ b/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "admin",
+      "password": "admin123"
+    },
+    {
+      "username": "teacher1",
+      "password": "password123"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要
Issue #5 の管理者モード機能を実装しました。

## 問題
学生が互いの登録を削除して、自分のためにスペースを確保していました。

## 解決策
教師のみが学生の登録と登録解除を行えるように、認証システムを追加しました。

## 実装内容

### バックエンド (FastAPI)
- ✅ 教師認証エンドポイント (`POST /auth/login`)
- ✅ `teachers.json` ファイルでユーザー管理
- ✅ 登録/登録解除エンドポイントに認証を要求
- ✅ Authorization ヘッダーによる認証検証
- ✅ CORS ミドルウェアの追加

### フロントエンド
- ✅ ログインモーダルの追加
- ✅ ヘッダーにユーザーメニュー（ログイン/ログアウトボタン）
- ✅ ローカルストレージで認証状態を管理
- ✅ ログイン時のみ登録フォームと削除ボタンを表示
- ✅ 未認証ユーザーは活動と参加者を閲覧可能

### セキュリティ
- 教師のみが登録/登録解除可能
- 学生は引き続き活動を閲覧可能
- シンプルな認証トークン（username:password）

## テスト方法
1. アプリケーションを起動
2. 右上の「👤 Login」ボタンをクリック
3. 以下の認証情報でログイン:
   - Username: `admin`
   - Password: `admin123`
4. ログイン後、登録フォームと削除ボタンが表示されることを確認
5. ログアウトして、これらが非表示になることを確認

## スクリーンショット
変更により:
- ヘッダーにユーザーアイコンとログインボタンが表示
- ログイン後、登録フォームが表示
- 各参加者の横に削除ボタン（❌）が表示（教師のみ）

Closes #5